### PR TITLE
Fix arrival date dropdown font color styling

### DIFF
--- a/src/components/ui/ArrivalDateSelect.tsx
+++ b/src/components/ui/ArrivalDateSelect.tsx
@@ -63,7 +63,7 @@ const ArrivalDateSelect = forwardRef<HTMLSelectElement, ArrivalDateSelectProps>(
         )}
         <select
           ref={ref}
-          className={`block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm ${
+          className={`w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 ${
             error ? 'border-red-500' : ''
           } ${className}`}
           value={value}


### PR DESCRIPTION
- Add text-gray-900 class to match other form fields
- Update focus ring styling to use ring-2 for consistency
- Remove block and sm:text-sm classes to match FormSelect/FormInput

🤖 Generated with [Claude Code](https://claude.ai/code)