### PR TITLE
Add Google Ads purchase success conversion tracking

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stripe/react-stripe-js';
 import { Language } from '@/lib/translations';
 import { trackPageView, trackButtonClick, trackEvent } from '@/lib/mixpanel';
-import { trackConversion } from '@/lib/gtag';
+import { trackPurchaseSuccess } from '@/lib/gtag';
 import QRCodeModal from '@/components/QRCodeModal';
 import { saveCompletedQR } from '@/lib/qr-storage';
 
@@ -195,9 +195,9 @@ export default function CheckoutPage() {
     }
   };
 
-  const handlePaymentSuccess = async () => {
-    // Track conversion for Google Ads (converting IDR to USD approximation for tracking)
-    trackConversion('checkout_completed', 30, 'USD');
+  const handlePaymentSuccess = async (paymentIntent?: Record<string, unknown>) => {
+    // Track conversion for Google Ads when QR code is about to be shown
+    trackPurchaseSuccess(paymentIntent?.id as string);
 
     // Scroll modal container to top for mobile visibility
     if (modalContainerRef.current) {

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -59,3 +59,15 @@ export const trackFormSubmission = (url?: string) => {
     });
   }
 };
+
+// Track purchase success conversion when QR code is shown
+export const trackPurchaseSuccess = (transactionId?: string) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-16915832546/0eW2CM6E14kbEOK9jII_',
+      'value': 1.0,
+      'currency': 'USD',
+      'transaction_id': transactionId || ''
+    });
+  }
+};


### PR DESCRIPTION
Implement conversion tracking for successful payments with QR code display:
- Add trackPurchaseSuccess function with conversion label 0eW2CM6E14kbEOK9jII_
- Track conversions when payment succeeds and QR code is shown
- Include Stripe transaction ID for better conversion attribution
- Replace generic checkout conversion with specific purchase success event

🤖 Generated with [Claude Code](https://claude.ai/code)